### PR TITLE
Fixed typo on readme.html

### DIFF
--- a/readme.html
+++ b/readme.html
@@ -64,7 +64,7 @@
 					<li>Create a mysql database. If you are unfamiliar with how to create a mysql database, please contact your web host or search their support site. Please pay careful attention when creating a database and write down your database name, username, password, and host somewhere.</li>
 					<li>Rename the /favicon.ico.default to /favicon.ico</li>
 					<li>Rename the /settings.php.default to /settings.php</li>
-					<li>Rename the /language/lang_english.conf.default file to lang_english.conf. Same instructions apply to any other language file that you might use that are located in the /languages directory.</li>
+					<li>Rename the /languages/lang_english.conf.default file to lang_english.conf. Same instructions apply to any other language file that you might use that are located in the /languages directory.</li>
 					<li>Rename the /libs/dbconnect.php.default file to dbconnect.php</li>
 					<li>Rename the directory /logs.default to /logs</li>
 					<li>Upload the files to your server.</li>


### PR DESCRIPTION
The language file renaming instruction was pointing to "language/lang_english.conf.default", the right path is "languages/lang_english.conf.default"